### PR TITLE
chore(deps): bump modular-bitfield to 0.12.0 and update derive usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ keywords = [
 embedded-hal = "1.0.0"
 embedded-can = "0.4.1"
 nb = "1.1.0"
-modular-bitfield = "0.11.2"
+modular-bitfield = "0.12.0"
 
 [features]
 mcp2515 = []

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::identity_op)] // FIXME https://github.com/Robbepop/modular-bitfield/issues/62
-
 use modular_bitfield::prelude::*;
 
 /// 8 bit Register
@@ -57,7 +55,7 @@ pub struct RXB1CTRL {
 
 /// Receive Buffer Operating Mode
 #[cfg(not(any(feature = "mcp2515", feature = "mcp25625")))]
-#[derive(BitfieldSpecifier, Copy, Clone, Debug)]
+#[derive(Specifier, Copy, Clone, Debug)]
 #[bits = 2]
 pub enum RXM {
     /// Receive all valid messages using either standard or extended identifiers that meet filter criteria
@@ -121,7 +119,7 @@ pub struct CANCTRL {
 }
 
 /// Request Operation mode
-#[derive(BitfieldSpecifier, Copy, Clone, Debug)]
+#[derive(Specifier, Copy, Clone, Debug)]
 #[bits = 3]
 pub enum OperationMode {
     NormalOperation = 0b000,
@@ -135,7 +133,7 @@ pub enum OperationMode {
 }
 
 /// CLKOUT Pin Prescaler
-#[derive(BitfieldSpecifier, Copy, Clone, Debug)]
+#[derive(Specifier, Copy, Clone, Debug)]
 #[bits = 2]
 pub enum CLKPRE {
     SystemClockDiv1 = 0b000,
@@ -177,7 +175,7 @@ pub struct CANSTAT {
 }
 
 /// Interrupt Flag Code
-#[derive(BitfieldSpecifier, Copy, Clone, Debug)]
+#[derive(Specifier, Copy, Clone, Debug)]
 #[bits = 3]
 pub enum InterruptFlagCode {
     NoInterrupt = 0b000,


### PR DESCRIPTION
**BREAKING CHANGE:** Replaces deprecated `BitfieldSpecifier` with `Specifier` macro as required by modular-bitfield 0.12.0. This may affect compatibility with existing enum definitions relying on the old derive macro.

Also removes workaround `#![allow(clippy::identity_op)]` previously required due to issue https://github.com/Robbepop/modular-bitfield/issues/62, which is now resolved in the new version.